### PR TITLE
Bug Fixes & Tweaks

### DIFF
--- a/docs/src/core/Constants.js
+++ b/docs/src/core/Constants.js
@@ -9,9 +9,6 @@ var doorBuffer = 6; // To prevent door spawning too close to edges of room
 var wallBuffer = 7; // To prevent wall shapes spawning too close to outer walls
 var step = 4;
 
-// Collision constants
-var pushback = 1; // Prevents sticking
-
 var knockbackForce = 5;
 
 // Room threat scaling constants

--- a/docs/src/core/sketch.js
+++ b/docs/src/core/sketch.js
@@ -2,7 +2,6 @@
 let game;
 let projectileManager;
 let behaviourMonitor;
-let asset_astrocat;
 
 let playerA;
 let playerB;
@@ -80,6 +79,7 @@ function gameSwitch(starting) {
     //theme_a.play();
   } else {
     inGame = false;
+    gameOver = false;
     game = null;
     projectileManager = null;
     behaviourMonitor = null;
@@ -94,6 +94,7 @@ function gameSwitch(starting) {
 
 function singlePlayerStart() {
   coop = false;
+  pvpMode = false;
   gameSwitch(true);
 }
 
@@ -168,7 +169,9 @@ function renderGameOverInterface() {
 
   if (coop) {
     scoretext_p1 =
-      " Player A: " + game.currScoreP1 + "\n" + "Player B: " + game.currScoreP2;
+      "Player A: " + game.currScoreP1 + "\n" + "Player B: " + game.currScoreP2;
+  } else if (pvpMode) {
+    scoretext_p1 = "";
   } else {
     scoretext_p1 = "Total Score: " + game.currScoreP1;
   }
@@ -328,15 +331,17 @@ function draw() {
       fill(255, 255, 255);
       var roomNumber = "Room " + game.roomSeq;
       text(roomNumber, 200, 80);
-      if (!coop) {
-        var scoreNumber = "Score:" + game.currScoreP1;
-        text(scoreNumber, 750, 80);
-      } else {
-        textSize(16);
-        var scoreNumber = "Score A:" + game.currScoreP1;
-        text(scoreNumber, 750, 70);
-        var scoreNumber = "Score B:" + game.currScoreP2;
-        text(scoreNumber, 750, 90);
+      if (!pvpMode) {
+        if (!coop) {
+          var scoreNumber = "Score:" + game.currScoreP1;
+          text(scoreNumber, 750, 80);
+        } else {
+          textSize(16);
+          var scoreNumber = "Score A:" + game.currScoreP1;
+          text(scoreNumber, 750, 70);
+          var scoreNumber = "Score B:" + game.currScoreP2;
+          text(scoreNumber, 750, 90);
+        }
       }
       pop();
 
@@ -374,16 +379,16 @@ function draw() {
         if (coop && game.slowMeowLevel == slowMeowMax &&
             playerA.fireOverheat && playerB.fireOverheat) {
           fill(210, 0, 0);
-          text("SLOW MEOW:BLOCKED", width / 2 + 20, height - 65);
+          text("SLOW MEOW:BLOCKED", width / 2 + 20, height - 63);
         } else if (!coop && game.slowMeowLevel == slowMeowMax && playerA.fireOverheat) {
           fill(210, 0, 0);
-          text("SLOW MEOW:BLOCKED", width / 2 + 20, height - 65);
+          text("SLOW MEOW:BLOCKED", width / 2 + 20, height - 63);
         } else if (!game.slowMeowUsable || game.slowMeowOccurring) {
           fill(100, 150, 255);
-          text("SLOW MEOW:" + Math.floor(game.slowMeowLevel) + "%", width / 2 + 20, height - 65);
+          text("SLOW MEOW:" + Math.floor(game.slowMeowLevel) + "%", width / 2 + 20, height - 63);
         } else if (!game.slowMeowOccurring && game.slowMeowUsable) {
           fill(0, 255, 255);
-          text("SLOW MEOW:READY", width / 2 + 20, height - 65);
+          text("SLOW MEOW:READY", width / 2 + 20, height - 63);
         }
       }
       pop();
@@ -410,8 +415,7 @@ function draw() {
     noStroke();
     fill(0, fadeAlpha);
     rect(0, 0, pageWidth, pageHeight);
-    if (game.gameState == GameStates.OVER && gameOver == false) {
-      console.log("GAMEOVER");
+    if (game.gameState == GameStates.OVER && !gameOver) {
       renderGameOverInterface();
       gameOver = true;
     }
@@ -458,8 +462,12 @@ function keyPressed() {
       }
     }
     // SlowMeow gets activated with 'Q' or '/'
-    if (!transitioning && (keyCode == 81 || keyCode == 191)) {
-      game.activateSlowMeow();
+    if (game && game.gameState == GameStates.ACTIVE) {
+      if (!transitioning && !pvpMode) {
+        if (keyCode == 81 || keyCode == 191) {
+          game.activateSlowMeow();
+        }
+      }
     }
   }
 }
@@ -471,5 +479,9 @@ function playSound(sound, rate) {
   source.buffer = sound.buffer;
   source.playbackRate.value = rate;
   source.connect(audioContext.destination);
+  // Disconnect after sound ends to prevent memory leaks etc.
+  source.onended = () => {
+    source.disconnect();
+  };
   source.start();
 }

--- a/docs/src/entities/base/Mob.js
+++ b/docs/src/entities/base/Mob.js
@@ -20,9 +20,18 @@ class Mob extends Sprite {
   }
 
   update() {
-    if (!this.isActive) {
-      return;
-    }
+    if (!this.isActive) return;
+    // Stops mob moving outside the outer walls
+    this.position.x = constrain(
+      this.position.x,
+      tileSize * 3 + arena_offset,
+      roomWidth * tileSize - tileSize * 3 + arena_offset
+    );
+    this.position.y = constrain(
+      this.position.y,
+      tileSize * 3 + arena_offset,
+      roomHeight * tileSize - tileSize * 3 + arena_offset
+    );
     let nearestPlayer = this.findNearestPlayer();
     if (nearestPlayer) {
       this.moveTowards(nearestPlayer);
@@ -82,17 +91,6 @@ class Mob extends Sprite {
     if (!this.isCollidingWith(player)) {
       this.velocity.x = xDirection * this.speed;
       this.velocity.y = yDirection * this.speed;
-    } else {
-      if (this.direction.x > 0) {
-        this.position.x -= pushback;
-      } else if (this.direction.x < 0) {
-        this.position.x += pushback;
-      }
-      if (this.direction.y > 0) {
-        this.position.y -= pushback;
-      } else if (this.direction.y < 0) {
-        this.position.y += pushback;
-      }
     }
     // Normalises diagonal movement
     if (this.velocity.x !== 0 && this.velocity.y !== 0) {

--- a/docs/src/entities/base/Player.js
+++ b/docs/src/entities/base/Player.js
@@ -15,6 +15,7 @@ class Player extends Sprite {
     this.fireRate = 200; // ms between shots
     this.originalFireRate = this.fireRate;
     this.lastShot = 0; // Timestamp of last shot
+    this.projectileSpeed = 10;
     this.inventory = [];
     this.direction = createVector(-1, 0); // Character starts facing right
     this.fireCooldown = 0; // Cooldown between shots
@@ -46,7 +47,7 @@ class Player extends Sprite {
     let playerAHealthBarX = 50;
     let playerAHealthBarY = 50;
     let playerAHealthRatio = playerA.health / playerA.maxHealth;
-    let frame = 13 - Math.round(13 * playerAHealthRatio);
+    let frame = 13 - Math.ceil(13 * playerAHealthRatio);
     let healthgif = image(healthbar, 40, 220);
     healthbar.pause();
     healthbar.setFrame(frame);
@@ -57,7 +58,7 @@ class Player extends Sprite {
       let playerBHealthBarY = 50;
       let playerBHealthRatio = playerB.health / playerB.maxHealth;
 
-      let frame = 13 - Math.round(13 * playerBHealthRatio);
+      let frame = 13 - Math.ceil(13 * playerBHealthRatio);
       let healthgifb = image(healthbar_b, 910, 220);
       healthbar_b.pause();
       healthbar_b.setFrame(frame);
@@ -78,9 +79,7 @@ class Player extends Sprite {
   }
 
   move() {
-    if (!this.isActive) {
-      return;
-    }
+    if (!this.isActive) return;
     this.overheatSlow();
 
     // Player movement using WASD / arrow keys
@@ -264,7 +263,7 @@ class Player extends Sprite {
           this.position.y,
           this.direction.x,
           this.direction.y,
-          10,
+          this.projectileSpeed,
           bullet,
           this
         );
@@ -290,7 +289,7 @@ class Player extends Sprite {
           this.position.y,
           this.direction.x,
           this.direction.y,
-          10,
+          this.projectileSpeed,
           bullet,
           this
         );
@@ -311,7 +310,6 @@ class Player extends Sprite {
   }
 
   drawPlayerHeatBar(x, y, width, height, value, label) {
-    if (!this.isActive) return;
     push();
     stroke(150);
     strokeWeight(2);

--- a/docs/src/entities/base/Projectile.js
+++ b/docs/src/entities/base/Projectile.js
@@ -11,20 +11,10 @@ class Projectile extends GameObject {
     this.widthHitbox = 5;
     this.heightHitbox = 5;
     this.owner = owner;
-    if (game && game.slowMeowOccurring) {
-      // Correct original velocity value for projectiles fired during slow meow state
-      if (this.originalVelocity.equals(this.velocity)) {
-        if (this.velocity.mag() < 1) {
-          this.originalVelocity = p5.Vector.div(this.velocity, game.slowMeowMovementSpeed);
-        } else {
-          this.originalVelocity = p5.Vector.div(this.velocity, game.slowMeowMovementSpeed + 1);
-        }
-      }
-      this.velocity = p5.Vector.mult(this.originalVelocity, game.slowMeowMovementSpeed);
-    }
   }
 
   update() {
+    if (!this.isActive) return;
     // Deactive the projectile if it leaves the room boundaries
     if (
       this.position.x < (tileSize * 2) + arena_offset ||
@@ -34,8 +24,23 @@ class Projectile extends GameObject {
     ) {
       this.isActive = false;
     }
-    if (this.isActive) {
-      this.position.add(this.velocity);
+
+    this.position.add(this.velocity);
+
+    if (game && game.slowMeowOccurring) {
+      // Correct original velocity value for projectiles fired during slow meow state
+      if (this.originalVelocity.equals(this.velocity)) {
+        if (this.velocity.mag() < 1) {
+          this.originalVelocity = p5.Vector.div(this.velocity, game.slowMeowMovementSpeed);
+        } else {
+          this.originalVelocity = p5.Vector.div(this.velocity, game.slowMeowMovementSpeed + 1);
+        }
+        if (this.owner.isBuffed && this.owner.speed > 0) {
+          this.originalVelocity.x = this.owner.velocity.x * (this.owner.projectileSpeed / game.slowMeowMovementSpeed);
+          this.originalVelocity.y = this.owner.velocity.y * (this.owner.projectileSpeed / game.slowMeowMovementSpeed);
+        }
+      }
+      this.velocity = p5.Vector.mult(this.originalVelocity, game.slowMeowMovementSpeed);
     }
   }
 

--- a/docs/src/entities/core/GameObject.js
+++ b/docs/src/entities/core/GameObject.js
@@ -14,11 +14,10 @@ class GameObject {
   }
 
   update() {
-    if (this.isActive) {
-      this.position.add(this.velocity);
+    if (!this.isActive) return;
 
-      // We can potentially add friction, gravity, walls
-    }
+    this.position.add(this.velocity);
+
     // Stops the object moving outside the outer walls (just in case)
     this.position.x = constrain(
       this.position.x,

--- a/docs/src/entities/mobs/BlinkMob.js
+++ b/docs/src/entities/mobs/BlinkMob.js
@@ -10,6 +10,7 @@ class BlinkMob extends Mob {
     this.speed = 0;
     this.originalSpeed = this.speed;
     this.attackDamage = 6 * difficultySettings.mobDamageMult;
+    this.projectileSpeed = 2;
     this.bloodColour = color(135, 20, 103, 255);
     this.fireCooldownLimit = 175;
     this.checkIfSlowMeowActive();
@@ -20,20 +21,19 @@ class BlinkMob extends Mob {
       this.blink();
       let projectileCount = 9;
       let angleIncrement = (2 * Math.PI) / projectileCount;
-      let projectileSpeed = 2;
 
       for (let i = 0; i < projectileCount; i++) {
         let angle = i * angleIncrement;
 
-        let velocityX = Math.cos(angle) * projectileSpeed;
-        let velocityY = Math.sin(angle) * projectileSpeed;
+        let velocityX = Math.cos(angle) * this.projectileSpeed;
+        let velocityY = Math.sin(angle) * this.projectileSpeed;
 
         let newProjectile = new Projectile(
           this.position.x,
           this.position.y,
           velocityX,
           velocityY,
-          3,
+          this.projectileSpeed + 1,
           fireball,
           this
         );

--- a/docs/src/entities/mobs/RangedMob.js
+++ b/docs/src/entities/mobs/RangedMob.js
@@ -8,6 +8,7 @@ class RangedMob extends Mob {
     this.speed = random(0.7, 1.1) * difficultySettings.mobSpeedMult;
     this.originalSpeed = this.speed;
     this.attackDamage = 8 * difficultySettings.mobDamageMult;
+    this.projectileSpeed = 3;
     this.bloodColour = color(255, 215, 80, 255);
     this.fireCooldownLimit = 100;
     this.checkIfSlowMeowActive();
@@ -16,16 +17,12 @@ class RangedMob extends Mob {
   fire() {
     let newProjectile;
     if (this.fireReady == true) {
-      let projectileSpeed = 3;
-      if (game && game.slowMeowOccuring) {
-        projectileSpeed = 3 / game.slowMeowMovementSpeed;
-      }
       newProjectile = new Projectile (
         this.position.x,
         this.position.y,
         this.velocity.x,
         this.velocity.y,
-        projectileSpeed,
+        this.projectileSpeed,
         fireball,
         this
       );

--- a/docs/src/room/Room.js
+++ b/docs/src/room/Room.js
@@ -561,7 +561,9 @@ class Room {
           }
         }
         playerA.applyKnockback(mob.position.x, mob.position.y);
-        mob.applyKnockback(playerA.position.x, playerA.position.y);
+        if (!(mob instanceof BlinkMob)) {
+          mob.applyKnockback(playerA.position.x, playerA.position.y);
+        }
         playerA.makeInvincible();
       }
 
@@ -582,7 +584,9 @@ class Room {
           }
         }
         playerB.applyKnockback(mob.position.x, mob.position.y);
-        mob.applyKnockback(playerB.position.x, playerB.position.y);
+        if (!mob instanceof BlinkMob) {
+          mob.applyKnockback(playerB.position.x, playerB.position.y);
+        }
         playerB.makeInvincible();
       }
     }
@@ -866,7 +870,6 @@ class Room {
       if (player.fireOverheat) playSound(overheatEndSound, playbackRate);
       player.resetOverheat();
     }
-
   }
 
   // Get the player's position in the next room based on position of door in current room


### PR DESCRIPTION
Changes:
- Fixed the game crashing if the player got more than 1 game over in a play session.
- Fixed not being able to start a single player game after quitting to the menu from a PvP game.
- Prevented any score text being drawn in PvP mode & on the PvP game over screen as there is no scoring system.
- Fixed a potential memory leak within the playSound function.
- Fixed the console complaining about game being null in certain situations.
- Removed some old code that has since been superseded.
- Prevented BlinkMobs from having knockback applied to them as it looked weird.
- Potentially fixed the player health bar frame calculations, so the health bar doesn't appear empty if the player still has health.
- Actually fixed the speed of a mob's projectiles if they are buffed and slow meow is active (maybe).
- Constrained mob positions in the room as the knockback effect could push them outside of the outer walls and cause sprite ghosting.
- Made the player's heat bar still be drawn even if the player is dead, as deactivating it caused ghosting (also a consistency change as their health bar doesn't stop being drawn when they die).